### PR TITLE
game.toml: make overlay_autocompile_cmd resolve on any machine

### DIFF
--- a/game.toml
+++ b/game.toml
@@ -55,7 +55,7 @@ overlay_backend = "auto"
 # injects PSX_OVERLAY_CACHE_DIR / PSX_OVERLAY_CAPTURES (the loader's canonical
 # <exe>/cache and <exe>/overlay_captures.json) so the write can never drift from
 # where the loader reads. This is just the compile RECIPE (compiler + tool paths).
-overlay_autocompile_cmd = "py -3 F:/Projects/psxrecomp/psxrecomp/tools/compile_overlays.py --game-toml game.toml --recompiler F:/Projects/psxrecomp/psxrecomp/recompiler/build/psxrecomp-game.exe --runtime-include F:/Projects/psxrecomp/psxrecomp/runtime/include --gcc C:/msys64/mingw64/bin/gcc.exe --cps"
+overlay_autocompile_cmd = "py -3 psxrecomp-v4/tools/compile_overlays.py --game-toml game.toml --recompiler psxrecomp-v4/recompiler/build/psxrecomp-game.exe --runtime-include psxrecomp-v4/runtime/include --cps"
 # tcc fallback: NO explicit cmd — when the backend resolves to tcc the runtime
 # constructs the command from the self-contained toolchain bundled beside the exe
 # (<exe>/overlay_toolchain/: embedded python + tcc + recompiler + script + headers).


### PR DESCRIPTION
The autocompile command must resolve from the project root on any clone. It did not — and a wrong path there is silent: every compile fails, no overlay shard is built, and the runtime falls back to the interpreter. The run looks normal, just slow, so any performance number taken from it is meaningless. That cost a full invalid measurement recently.

Normalised onto the form other titles already use:
- in-repo framework directory (no absolute `F:/…`, no sibling `../psxrecomp`)
- standard `recompiler/build/` output dir
- `py -3` (bare `python` can bind to a Cygwin build that SIGSEGVs under the autocompile job spawn — failing with no output at all)
- no absolute `--gcc`; it resolves from PATH, with `PSX_MINGW_BIN` as the override

Title-specific flags (`--captures`, `--out-dir`, `--cps`, coverage-vault merge, runtime build dir) are untouched — those are configuration, not portability bugs.

Complements psxrecomp master, which now detects a missing path at configure time and reports it as `degraded`/`degraded_reason` in `autocompile_status` and in `psx_last_run_report.json` instead of degrading silently.