### PR TITLE
release: verify every fetched toolchain archive against a SHA256 pin

### DIFF
--- a/tools/package_release.ps1
+++ b/tools/package_release.ps1
@@ -244,20 +244,63 @@ New-Item -ItemType Directory -Force $Toolchain | Out-Null
 $DlCache = Join-Path $Root "tools/_toolchain_cache"
 New-Item -ItemType Directory -Force $DlCache | Out-Null
 
+# Pin every fetched archive by SHA256 and verify on EVERY use, including cache
+# hits. Without this a release trusts whatever the mirror served that day, and a
+# corrupted/tampered file already in tools/_toolchain_cache is reused forever
+# because the old code only checked Test-Path. Mirrors (python.org, savannah)
+# both 502 periodically, so transient failures retry instead of losing a build.
+function Get-PinnedArchive {
+    param(
+        [Parameter(Mandatory)][string]$Uri,
+        [Parameter(Mandatory)][string]$Sha256,
+        [Parameter(Mandatory)][string]$Destination,
+        [int]$Retries = 4
+    )
+    $name = Split-Path -Leaf $Destination
+    if (Test-Path -LiteralPath $Destination) {
+        $have = (Get-FileHash -LiteralPath $Destination -Algorithm SHA256).Hash.ToLower()
+        if ($have -eq $Sha256.ToLower()) { return $Destination }
+        Write-Warning "$name in the download cache has SHA256 $have (expected $Sha256); refetching"
+        Remove-Item -LiteralPath $Destination -Force
+    }
+    for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+        try {
+            $tmp = "$Destination.tmp"
+            if (Test-Path -LiteralPath $tmp) { Remove-Item -LiteralPath $tmp -Force }
+            Invoke-WebRequest -Uri $Uri -OutFile $tmp -UseBasicParsing
+            $got = (Get-FileHash -LiteralPath $tmp -Algorithm SHA256).Hash.ToLower()
+            if ($got -ne $Sha256.ToLower()) {
+                Remove-Item -LiteralPath $tmp -Force
+                throw "SHA256 mismatch for $name : got $got, expected $Sha256"
+            }
+            Move-Item -LiteralPath $tmp -Destination $Destination -Force
+            return $Destination
+        } catch {
+            if ($attempt -eq $Retries) {
+                throw ("Failed to fetch $name after $Retries attempts: $($_.Exception.Message). " +
+                       "Place a verified copy at $Destination and re-run.")
+            }
+            $delay = [Math]::Min(30, [Math]::Pow(2, $attempt))
+            Write-Warning "$name fetch attempt $attempt failed ($($_.Exception.Message)); retrying in ${delay}s"
+            Start-Sleep -Seconds $delay
+        }
+    }
+}
+
 # Embedded Python (fixed version; downloaded once + cached)
 $PyVer = "3.13.1"
-$PyZip = Join-Path $DlCache "python-$PyVer-embed-amd64.zip"
-if (-not (Test-Path $PyZip)) {
-    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/$PyVer/python-$PyVer-embed-amd64.zip" -OutFile $PyZip
-}
+$PyZip = Get-PinnedArchive `
+    -Uri "https://www.python.org/ftp/python/$PyVer/python-$PyVer-embed-amd64.zip" `
+    -Sha256 "7b7923ff0183a8b8fca90f6047184b419b108cb437f75fc1c002f9d2f8bcec16" `
+    -Destination (Join-Path $DlCache "python-$PyVer-embed-amd64.zip")
 Expand-Archive -Path $PyZip -DestinationPath (Join-Path $Toolchain "python") -Force
 
 # TinyCC prebuilt win64 (fixed version; downloaded once + cached). The zip has a
 # top-level tcc/ dir (tcc.exe + libtcc.dll + include/ + lib/) — ship it whole.
-$TccZip = Join-Path $DlCache "tcc-0.9.27-win64-bin.zip"
-if (-not (Test-Path $TccZip)) {
-    Invoke-WebRequest -Uri "https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip" -OutFile $TccZip
-}
+$TccZip = Get-PinnedArchive `
+    -Uri "https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip" `
+    -Sha256 "34a721949a2583fdff725312da092fa0f5f1f284b702e6f811c6954714faabb2" `
+    -Destination (Join-Path $DlCache "tcc-0.9.27-win64-bin.zip")
 $TccTmp = Join-Path $DlCache "tcc_extract"
 if (Test-Path $TccTmp) { Remove-Item -Recurse -Force $TccTmp }
 Expand-Archive -Path $TccZip -DestinationPath $TccTmp -Force


### PR DESCRIPTION
## Problem

`tools/package_release.ps1` fetched the embedded Python and the TinyCC prebuilt with a bare `Invoke-WebRequest`, guarded only by `Test-Path`:

```powershell
if (-not (Test-Path $PyZip)) {
    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/$PyVer/..." -OutFile $PyZip
}
```

Two consequences:

- A release trusted whatever the mirror served that day. Nothing tied the shipped toolchain to a known-good file.
- Once a corrupted or tampered archive landed in `tools/_toolchain_cache`, it was reused **forever** — `Test-Path` cannot tell a good zip from a bad one.

Both of these ship inside the release artifact, so a bad fetch becomes a bad download for every player.

## Fix

`Get-PinnedArchive` verifies SHA256 on **every** use, cache hits included, and refetches when a cached file does not match. Both mirrors (python.org, savannah) 502 periodically, so a fetch retries with exponential backoff instead of losing a build, and the terminal failure names the path to drop a verified copy at.

## Pins verified independently

Not just self-consistently — the pin was checked against upstream and across time:

| Archive | Evidence |
|---|---|
| `python-3.13.1-embed-amd64.zip` | Matches python.org's **published MD5** `d5c8030976b5eaf55ed6b321c073dda7`, and its size (10,847,803 B) matches the listed 10.3 MB |
| `tcc-0.9.27-win64-bin.zip` | Savannah publishes no checksum; the pin reproduces byte-for-byte across two independent downloads |

Both pins reproduce byte-for-byte across archives downloaded weeks apart (Jun 25 and Jul 3) into two different title repos, and both match the pins already in the framework's shared staging module.

## Behaviour verified, not just read

Script parses clean (`Parser::ParseFile`, 0 errors). `Get-PinnedArchive` was extracted and exercised directly:

- **Cache hit, correct hash** → returns the path in 0.05 s with an unresolvable URI, proving no fetch is attempted.
- **Uppercase expected hash** → still matches (comparison is case-insensitive both ways).
- **Tampered cached file** → warns with both the actual and expected hash, deletes the bad file, attempts a refetch, and throws a message naming the recovery path. No `.tmp` litter left behind.

The tampered-file case is the one that matters: before this change it returned the bad archive silently.

## Note on duplication

`Get-PinnedArchive` also now exists in the framework's shared staging module (`psxrecomp` `tools/release_overlay_stage.ps1`). This inline copy is **deliberately temporary**: MegaManX6's turn in the per-title packager migration replaces it with a dot-source of the shared module, so the pins end up in exactly one place. Landing it now means MegaManX6 is not left unpinned in the meantime.

## Scope

One file, one concern. Branched off `origin/master` so it carries nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)