### PR TITLE
mods: let the framework stage the catalog; fix a ctest that deleted the repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,23 @@ file(GLOB MMX6_MOD_PLUGIN_SOURCES CONFIGURE_DEPENDS
 file(GLOB GAME_MOD_RESOLVER_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mods/*.cpp")
 
+# The game-owned mod catalog (the two presentation enhancements plus the
+# acediez Tweaks set). Every feature stays disabled until selected on the
+# launcher's Mods page.
+#
+# The FRAMEWORK stages it: PRELOADED_MODS_DIR below hands the directory to
+# psxrecomp_add_runtime_target(), which wipes <exe-dir>/mods/bundled and copies
+# both its own mods/builtin/packages and these packages into it, plus
+# mods/preloaded/README.md -> mods/README.md. This repo must NOT copy the tree
+# itself. It used to, with a hand-written POST_BUILD copy_directory into
+# <exe-dir>/mods, and because that named the destination as a STRING, framework
+# commit 4cc04be3's rename of the staged catalog from mods/packages to
+# mods/bundled broke it silently -- nothing a configure, compile or link step
+# can see. The 15 mmx6.* packages went on landing in mods/packages, which
+# neither the launcher nor the release packager's Add-ModCatalog reads.
+# Bead beads-eio.3.101.
+set(MMX6_PRELOADED_MODS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded")
+
 psxrecomp_v4_add_runtime_target(psx-runtime
     GAME_GENERATED_FULL_C "${GAME_GENERATED_FULL}"
     GAME_GENERATED_DISPATCH_C "${GAME_GENERATED_DISPATCH}"
@@ -53,22 +70,12 @@ psxrecomp_v4_add_runtime_target(psx-runtime
     DEFAULT_GAME_CONFIG_PATH "game.toml"
     EXE_NAME "mmx6-runtime"
     LAUNCHER_BOXART "${CMAKE_SOURCE_DIR}/recomp/launcher/boxart.tga"
+    PRELOADED_MODS_DIR "${MMX6_PRELOADED_MODS}"
     EXTRAS_SOURCES
         ${GAME_GENERATED_EXTRAS}
         ${MMX6_MOD_PLUGIN_SOURCES}
         ${GAME_MOD_RESOLVER_SOURCES}
 )
-
-# Ship the game-owned mod catalog beside the executable. Every feature stays
-# disabled until selected on the launcher's Mods page.
-set(MMX6_PRELOADED_MODS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded")
-if(EXISTS "${MMX6_PRELOADED_MODS}/packages")
-    add_custom_command(TARGET psx-runtime POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${MMX6_PRELOADED_MODS}"
-            "$<TARGET_FILE_DIR:psx-runtime>/mods"
-        COMMENT "Preloading the Mega Man X6 mod catalog")
-endif()
 
 # First-divergence co-sim oracle build (COSIM_ORACLE.md): clean, deterministic,
 # PSX_NO_DEBUG_TOOLS + PSX_COSIM. Two of these (one normal, one PSX_FORCE_INTERP=1)
@@ -100,18 +107,26 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/launcher_art")
         COMMENT "Overriding launcher art with MegaManX6Recomp/launcher_art")
 endif()
 
+# Framework sources these tests compile in are addressed through
+# ${PSXRECOMP_V4_ROOT}, not the bare relative path "psxrecomp-v4/...". The
+# relative spelling only resolved when the submodule/junction was populated
+# in-tree, so `-DPSXRECOMP_V4_ROOT=<worktree>` -- the way a title is validated
+# against a framework branch without moving its submodule pin -- failed to
+# generate at all ("No SOURCES given to target: mmx6_preloaded_mods_test").
+# A title that cannot be built against framework master cannot be checked
+# against it either.
 if(BUILD_TESTING)
     add_executable(mmx6_tweaks_hooks_test
         tests/test_mmx6_tweaks_hooks.cpp
         src/mods/mmx6_tweaks_hooks_resolver.cpp
-        psxrecomp-v4/runtime/src/mod_packages.cpp
-        psxrecomp-v4/runtime/src/crc32.c
-        psxrecomp-v4/runtime/src/psx_sha256.c
+        "${PSXRECOMP_V4_ROOT}/runtime/src/mod_packages.cpp"
+        "${PSXRECOMP_V4_ROOT}/runtime/src/crc32.c"
+        "${PSXRECOMP_V4_ROOT}/runtime/src/psx_sha256.c"
     )
     target_include_directories(mmx6_tweaks_hooks_test PRIVATE
         src/mods
-        psxrecomp-v4/runtime/include
-        psxrecomp-v4/recompiler/lib/toml11
+        "${PSXRECOMP_V4_ROOT}/runtime/include"
+        "${PSXRECOMP_V4_ROOT}/recompiler/lib/toml11"
     )
     add_test(
         NAME mmx6_tweaks_hooks_test
@@ -125,14 +140,14 @@ if(BUILD_TESTING)
     add_executable(mmx6_preloaded_mods_test
         tests/test_preloaded_mods.cpp
         ${GAME_MOD_RESOLVER_SOURCES}
-        psxrecomp-v4/runtime/src/mod_packages.cpp
-        psxrecomp-v4/runtime/src/crc32.c
-        psxrecomp-v4/runtime/src/psx_sha256.c
+        "${PSXRECOMP_V4_ROOT}/runtime/src/mod_packages.cpp"
+        "${PSXRECOMP_V4_ROOT}/runtime/src/crc32.c"
+        "${PSXRECOMP_V4_ROOT}/runtime/src/psx_sha256.c"
     )
     target_include_directories(mmx6_preloaded_mods_test PRIVATE
         src/mods
-        psxrecomp-v4/runtime/include
-        psxrecomp-v4/recompiler/lib/toml11
+        "${PSXRECOMP_V4_ROOT}/runtime/include"
+        "${PSXRECOMP_V4_ROOT}/recompiler/lib/toml11"
     )
     add_test(
         NAME mmx6_preloaded_mods_test
@@ -164,15 +179,15 @@ if(BUILD_TESTING)
 
     add_executable(mmx6_tweaks_timing_runtime_test
         tools/test_tweaks_timing_runtime.cpp
-        psxrecomp-v4/runtime/src/mod_packages.cpp
-        psxrecomp-v4/runtime/src/crc32.c
-        psxrecomp-v4/runtime/src/psx_sha256.c
+        "${PSXRECOMP_V4_ROOT}/runtime/src/mod_packages.cpp"
+        "${PSXRECOMP_V4_ROOT}/runtime/src/crc32.c"
+        "${PSXRECOMP_V4_ROOT}/runtime/src/psx_sha256.c"
     )
     add_dependencies(mmx6_tweaks_timing_runtime_test
         mmx6_timing_test_package)
     target_include_directories(mmx6_tweaks_timing_runtime_test PRIVATE
-        psxrecomp-v4/runtime/include
-        psxrecomp-v4/recompiler/lib/toml11
+        "${PSXRECOMP_V4_ROOT}/runtime/include"
+        "${PSXRECOMP_V4_ROOT}/recompiler/lib/toml11"
     )
     add_test(
         NAME mmx6_tweaks_timing_runtime_test

--- a/packaging/release/app.conf
+++ b/packaging/release/app.conf
@@ -17,9 +17,17 @@ PAYLOAD_DIR="megamanx6recomp"
 DESKTOP_ID="io.github.mstan.MegaManX6Recomp"
 ENV_PREFIX="MMX6_RECOMP"
 ICON_SOURCE="recomp/launcher/boxart.tga"
-# Mod packages in the SHIPPED catalog: this title's 15 (2 enhancements + the
-# acediez Tweaks set) plus the two the framework stages for every game
-# (loading speed). The packagers refuse to build if the count does not match,
-# so an empty or half-staged Mods page cannot ship.
-EXPECTED_MODS=17
+# Manifests in the SHIPPED catalog, which the AppImage scripts count with
+# `find <payload>/mods -name manifest.toml`. That is the WHOLE staged catalog:
+# this title's 15 (2 enhancements + the acediez Tweaks set) plus the four the
+# framework stages for every game (psx.enhancement.cd-speed / fast-loading /
+# pgxp, psx.presentation.bezel) = 19. Measured from a real build output.
+#
+# It said 17, from when the framework staged two. The count is checked with
+# -ne, so it had already gone stale and would fail the AppImage packager. A
+# count that describes one side of a catalog two repositories contribute to
+# cannot help but rot; the Windows packager no longer uses one (it asserts, via
+# the framework's Add-ModCatalog, that every package the SOURCES define reached
+# the staged catalog). Doing the same on the Linux side is worth a follow-up.
+EXPECTED_MODS=19
 FRAMEWORK_DIR="psxrecomp-v4"

--- a/tests/test_preloaded_mods.cpp
+++ b/tests/test_preloaded_mods.cpp
@@ -23,10 +23,37 @@ int fail(const std::string& message) {
 int main(int argc, char** argv) {
     if (argc != 2) return fail("expected the preloaded mods root");
 
-    const std::filesystem::path root(argv[1]);
+    // Work on a COPY, never on the repository.
+    //
+    // ModPackageManager::scan() calls migrate_legacy_root(), which treats
+    // <root>/packages as the pre-split build-output layout and relocates every
+    // package it finds there into <root>/installed. The source convention for a
+    // title's own catalog is mods/preloaded/PACKAGES -- the same directory name
+    // -- so pointing the manager straight at argv[1] made this test DELETE the
+    // repository's mod catalog: measured 2026-09-02, all 15 package families
+    // (278 tracked files, including the approved retranslation payload) moved
+    // out of mods/preloaded/packages into mods/preloaded/installed on the first
+    // ctest run, after which the test failed on its own vandalism with
+    // "approved retranslation payload is missing". A green run only ever
+    // happened because nobody ran it twice in the same checkout.
+    //
+    // ApeEscapeRecomp's and Tomba2Recomp's equivalents already copy first. This
+    // does the same, and scans only the copy so no path in the repo is touched.
+    const std::filesystem::path source(argv[1]);
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / "mmx6-preloaded-mods-test";
+    std::error_code copy_ec;
+    std::filesystem::remove_all(root, copy_ec);
+    std::filesystem::copy(source, root,
+                          std::filesystem::copy_options::recursive, copy_ec);
+    if (copy_ec) {
+        return fail("could not stage a copy of " + source.string() + ": " +
+                    copy_ec.message());
+    }
+
     size_t manifest_count = 0;
     for (const std::filesystem::directory_entry& entry :
-         std::filesystem::recursive_directory_iterator(root / "packages")) {
+         std::filesystem::recursive_directory_iterator(source / "packages")) {
         if (!entry.is_regular_file() ||
             entry.path().filename() != "manifest.toml") {
             continue;
@@ -135,8 +162,12 @@ int main(int argc, char** argv) {
                     " linked Tweaks packages, found " +
                     std::to_string(linked_tweaks_packages));
     }
+    // Against the SOURCE tree, not the scanned copy: scan() has by now
+    // migrated <root>/packages away (see the note in main()), so asserting the
+    // on-disk shape of packages/ after a scan asserts the shape of a directory
+    // the scan just emptied. This assertion is about what the repository ships.
     if (!std::filesystem::exists(
-            root / "packages" / "mmx6.tweaks.native" / "1.10.5" /
+            source / "packages" / "mmx6.tweaks.native" / "1.10.5" /
             "assets" / "retranslation")) {
         return fail("approved retranslation payload is missing");
     }

--- a/tools/package_release.ps1
+++ b/tools/package_release.ps1
@@ -96,19 +96,29 @@ Copy-Item (Join-Path $Root "LICENSE") $Stage
 # PLUS the ones the framework stages for every game (loading speed). Copying
 # the source tree instead silently drops the framework's mods from the
 # release, so players get a Mods page missing entries the dev build shows.
-$ModsSrc = Join-Path $BuildPath "mods"
-if (Test-Path (Join-Path $ModsSrc "packages")) {
-    Copy-Item -Recurse -Force $ModsSrc (Join-Path $Stage "mods")
-    $preloadedCount = (Get-ChildItem (Join-Path $Stage "mods/packages") -Directory).Count
-    Write-Host "Bundled mod catalog: $preloadedCount package family/families"
-    if ($preloadedCount -lt 16) {
-        throw ("Expected the game's 15 packages plus the framework's " +
-               "loading-speed mods, found $preloadedCount. The framework " +
-               "catalog is missing from $ModsSrc.")
-    }
-} else {
-    throw "No mod catalog staged at $ModsSrc - build the runtime first"
-}
+#
+# Routed through the framework's shared Add-ModCatalog. The hand-written block
+# that used to live here was wrong twice over:
+#
+#   * it globbed mods/packages, the PRE-SPLIT layout. Framework 4cc04be3 moved
+#     staged build output to mods/bundled and nothing in this repo followed, so
+#     at framework master this threw "No mod catalog staged ... build the
+#     runtime first" -- a message that blames the build for a layout rename
+#     (bead beads-eio.3.101);
+#   * it asserted "at least 16 package families". A count describes only one
+#     side of a catalog two repositories contribute to, so it goes stale the
+#     moment either side gains a mod. The identical assertion made Tomba 2
+#     unreleasable on 2026-09-01 when the framework gained a fifth builtin.
+#
+# Add-ModCatalog asserts the invariant instead: every package the SOURCES
+# define -- this repo's mods/preloaded/packages and the framework's
+# mods/builtin/packages -- must survive into the staged catalog. It also strips
+# the two things under mods/ that belong to this machine (installed/ and
+# state.toml) rather than leaving them to be noticed later.
+. (Join-Path $FrameworkRoot "tools\release_overlay_stage.ps1")
+Add-ModCatalog -BuildPath $BuildPath -Stage $Stage `
+               -GameModSource (Join-Path $Root "mods\preloaded") `
+               -FrameworkModSource (Join-Path $FrameworkRoot "mods\builtin") | Out-Null
 $BundledBiosSrc = Join-Path $BuildPath "bios"
 if (!(Test-Path (Join-Path $BundledBiosSrc "openbios.bin")) -or
     (Get-Item (Join-Path $BundledBiosSrc "openbios.bin")).Length -ne 524288 -or


### PR DESCRIPTION
## What

This repo staged its own mod catalog with a hand-written POST_BUILD `copy_directory` into `$<TARGET_FILE_DIR:psx-runtime>/mods`, and `mods/preloaded` contains `packages/`, so all 15 `mmx6.*` packages landed in `<exe>/mods/packages`. Framework commit `4cc04be3` renamed the staged catalog to `<exe>/mods/bundled` — the framework's staging, the launcher's scan and the shared release module all moved — and nothing here followed, because that destination is a **string** with no compile-time or link-time consumer.

Bead `beads-eio.3.101`. Framework fix: **mstan/psxrecomp#305**.

`CMakeLists.txt` now declares the directory via that PR's `PRELOADED_MODS_DIR` argument instead of copying it.

## Measured — real build output

Framework `fix/framework-owns-mod-catalog-staging`, recomp-ui `d8187a4`, `-DCMAKE_BUILD_TYPE=Release`:

```
Staging mod catalog for psx-runtime (19 package(s) -> mods/bundled)
-- [psx-runtime] staged mod catalog OK: 19 package(s) = 15 game-owned + 4 framework-owned,
   all under mods/bundled, no mods/packages
```

`mods/README.md` present, 19 `manifest.toml`, all under `mods/bundled/<id>/<version>/`, no `mods/packages`, no `mods/state.toml`, no `mods/installed`.

```
100% tests passed, 0 tests failed out of 4
  mmx6_tweaks_hooks_test / mmx6_preloaded_mods_test
  mmx6_tweaks_timing_runtime_test / psx_staged_mod_catalog_test
```

## Three other things had to change — same defect, different clothes

**1. `tools/package_release.ps1`** globbed `mods/packages` and asserted "at least 16 package families". At framework master its `Test-Path` failed and it threw `No mod catalog staged at ... - build the runtime first`, blaming the build for a layout rename. The count was also wrong by construction — it describes one side of a catalog two repositories contribute to, so it goes stale the moment either side gains a mod; the identical assertion made Tomba 2 unreleasable on 2026-09-01 when the framework gained a fifth builtin. It now dot-sources `psxrecomp-v4/tools/release_overlay_stage.ps1` and calls `Add-ModCatalog`, which asserts the **invariant**: every package the sources define must survive into the staged catalog. Verified against this build output:

```
Bundled mod catalog: 19 package(s) = 15 game-owned + 4 framework-owned
```

**2. `packaging/release/app.conf`** said `EXPECTED_MODS=17`, from when the framework staged two builtins. The AppImage scripts count `manifest.toml` recursively under `mods/` and compare with `-ne`, so that had already gone stale and would fail the Linux packager. The real figure, measured from build output, is 19. Same rot, different file — a follow-up should replace the Linux count with the derived assertion the Windows side now uses.

**3. The `BUILD_TESTING` block** addressed framework sources as bare relative paths (`psxrecomp-v4/runtime/src/mod_packages.cpp`) rather than through `${PSXRECOMP_V4_ROOT}`. That resolved only when the submodule/junction was populated in-tree, so `-DPSXRECOMP_V4_ROOT=<worktree>` — the way a title is validated against a framework branch without moving its pin — failed to generate at all:

```
CMake Error at CMakeLists.txt:172 (add_executable):
  No SOURCES given to target: mmx6_preloaded_mods_test
```

A title that cannot be *built* against framework master cannot be *checked* against it either, which is part of why a framework layout change reached five titles unnoticed.

## And a destructive ctest, found by running ctest in a clean worktree

`tests/test_preloaded_mods.cpp` constructed `ModPackageManager` directly on `argv[1]` — the **repository's** `mods/preloaded`. `ModPackageManager::scan()` calls `migrate_legacy_root()`, which treats `<root>/packages` as the pre-split build-output layout and relocates every package it finds there into `<root>/installed`. The source convention for a title's own catalog is `mods/preloaded/`**`packages`** — the same directory name. So the test moved the repository's entire mod catalog out from under itself.

Measured 2026-09-02, first ctest run in a fresh worktree: all 15 package families — **278 tracked files**, including the approved retranslation payload — moved from `mods/preloaded/packages` to `mods/preloaded/installed`, after which the test failed on its own vandalism:

```
FAIL: approved retranslation payload is missing
```

This is a third face of `4cc04be3`: `migrate_legacy_root` did not exist before it, so the test passed before the framework moved and has been broken-**and-destructive** since. It only ever looked green because nobody ran it twice in the same checkout.

The test now copies the catalog to a temp directory before scanning — exactly as ApeEscapeRecomp's and Tomba2Recomp's equivalents already do — and asserts the on-disk shape of the **source** tree rather than of a directory the scan just emptied. Verified: passes twice in a row, and `git status mods/` reports zero deletions afterwards.

That a read-shaped API mutates the tree it is pointed at deserves its own bead against the framework. This PR only stops this repo from being the victim.

## Shipped releases are not affected

An older release pins a framework from before the split and is self-consistent with it. **This is a forward break only.**

## Merge order

**mstan/psxrecomp#305 must merge FIRST.** `PRELOADED_MODS_DIR` does not exist before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
