### PR TITLE
Unify release staging with psxrecomp

### DIFF
--- a/packaging/linux/AppRun
+++ b/packaging/linux/AppRun
@@ -94,7 +94,29 @@ fi
 
 launcher=$data_dir/.@EXE_NAME@-runtime
 ln -sfn "$runtime" "$launcher"
-export @ENV_PREFIX@_APPIMAGE_PATH=${APPIMAGE:-}
+appimage_path=${APPIMAGE:-}
+export @ENV_PREFIX@_APPIMAGE_PATH=$appimage_path
+export RECOMP_APPIMAGE_PATH=$appimage_path
+
+# An explicit validation/runtime override may preselect a disc without baking
+# a developer path into the reproducible release configuration.
+disc_override=${@ENV_PREFIX@_DISC:-}
+if [ -n "$disc_override" ] && [ -f "$disc_override" ]; then
+    config_tmp=$data_dir/.game.toml.tmp
+    awk -v disc="$disc_override" '
+        BEGIN { inserted = 0 }
+        /^[[:space:]]*disc[[:space:]]*=/ { next }
+        /^\[/ && $0 != "[game]" && !inserted {
+            escaped = disc
+            gsub(/\\/, "\\\\", escaped)
+            gsub(/"/, "\\\"", escaped)
+            print "disc = \"" escaped "\""
+            inserted = 1
+        }
+        { print }
+    ' "$data_dir/game.toml" > "$config_tmp"
+    mv "$config_tmp" "$data_dir/game.toml"
+fi
 unset APPIMAGE
 
 export PATH="$APPDIR/usr/bin${PATH:+:$PATH}"

--- a/tools/package_appimage.sh
+++ b/tools/package_appimage.sh
@@ -215,6 +215,7 @@ if [ "$skip_build" = "0" ]; then
     # otherwise identical builds differ.
     cmake -S "$root" -B "$build_dir" -G "$generator" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DPSX_SDL_BACKEND=SDL2 \
         -DPSX_DEBUG_TOOLS=OFF \
         -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id=none"
     cmake --build "$build_dir" --target psx-runtime -j "$jobs"
@@ -261,6 +262,13 @@ game_id=$(sed -n 's/^[[:space:]]*id[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' 
 
 recompiler_bin=$fw/$bios_build/psxrecomp-game
 [ -x "$recompiler_bin" ] || recompiler_bin=$fw/recompiler/build-linux/psxrecomp-game
+if [ ! -x "$recompiler_bin" ]; then
+    recompiler_build=$(dirname -- "$recompiler_bin")
+    gen=Ninja
+    command -v ninja >/dev/null 2>&1 || gen="Unix Makefiles"
+    cmake -S "$fw/recompiler" -B "$recompiler_build" -G "$gen" -DCMAKE_BUILD_TYPE=Release
+    cmake --build "$recompiler_build" --target psxrecomp-game -j "$jobs"
+fi
 cg_tag=$(psx_overlay_cg_tag \
     --runtime-include "$fw/runtime/include" \
     --recompiler "$recompiler_bin" \

--- a/tools/package_release.ps1
+++ b/tools/package_release.ps1
@@ -10,7 +10,7 @@ param(
     # Where your accumulated overlay cache lives (the dir compile_overlays.py
     # writes to, per game.toml overlay_autocompile_cmd --out-dir). Bundled as a
     # head start.
-    [string]$CacheBuildDir = "build-stable",
+    [string]$CacheBuildDir = "build-release",
     [switch]$SkipRegen
 )
 
@@ -73,6 +73,42 @@ function Get-TomlScalar {
     }
     return $null
 }
+
+function Ensure-BiosBackends {
+    param([Parameter(Mandatory)][string]$FrameworkRoot)
+    $stems = @()
+    if (Test-Path -LiteralPath (Join-Path $FrameworkRoot "bios\OpenBIOS.toml")) {
+        $stems += ,@("OpenBIOS", "bios/OpenBIOS.toml")
+    }
+    if (Test-Path -LiteralPath (Join-Path $FrameworkRoot "bios\SCPH1001.BIN")) {
+        $stems += ,@("SCPH1001", "bios/SCPH1001.toml")
+    }
+    if (-not $stems) { throw "No BIOS profile available under $FrameworkRoot\bios" }
+
+    $missing = @($stems | Where-Object {
+        -not (Test-Path -LiteralPath (Join-Path $FrameworkRoot ("generated\{0}_dispatch.c" -f $_[0])))
+    })
+    if (-not $missing) { return }
+
+    $bash = $null
+    foreach ($cand in @("C:\msys64\usr\bin\bash.exe", "C:\msys64\mingw64\bin\bash.exe")) {
+        if (Test-Path -LiteralPath $cand) { $bash = $cand; break }
+    }
+    if (-not $bash) {
+        throw ("Missing recompiled BIOS backend(s): {0}. Install MSYS2 or run " +
+               "psxrecomp-v4/tools/regen_bios.sh manually." -f (($missing | ForEach-Object { $_[0] }) -join ', '))
+    }
+
+    $cygpath = Join-Path (Split-Path -Parent $bash) "cygpath.exe"
+    $posixRoot = (& $cygpath -u $FrameworkRoot).Trim()
+    $posixMingw = (& $cygpath -u $MingwBin).Trim()
+    foreach ($stem in $missing) {
+        Write-Host "Generating recompiled BIOS backend: $($stem[0])"
+        $biosShellCmd = "export PATH='$posixMingw':`$PATH; cd '$posixRoot' && " +
+                        "PSXRECOMP_BIOS_BUILD=recompiler/build tools/regen_bios.sh --config $($stem[1])"
+        Invoke-Native { & $bash -c $biosShellCmd } "regen_bios ($($stem[0]))"
+    }
+}
 # The executable is generated from the developer config but runs against the
 # player config. Keep widescreen codegen and runtime gates identical.
 Invoke-Native {
@@ -86,9 +122,11 @@ if (-not (Test-Path $FrameworkRoot)) {
 $RecompDir = Resolve-Path (Join-Path $FrameworkRoot "recompiler\build")
 if (-not $SkipRegen) {
     Invoke-Native { cmake --build $RecompDir --target psxrecomp-game -j $env:NUMBER_OF_PROCESSORS } "recompiler build"
+    Ensure-BiosBackends -FrameworkRoot $FrameworkRoot
     & (Join-Path $RecompDir "psxrecomp-game.exe") --config (Join-Path $Root "game.toml")
     if ($LASTEXITCODE -ne 0) { throw "game regen failed" }
 } else {
+    Ensure-BiosBackends -FrameworkRoot $FrameworkRoot
     Write-Host "Skipping game C regeneration; packaging the existing generated sources"
 }
 


### PR DESCRIPTION
Pins psxrecomp-v4 to a7459cdd and moves Windows/Linux packaging onto the shared psxrecomp staging path. Validated Windows zip by extraction and 180s packaged soak with bundled cache/toolchain fallback. Validated Linux AppImage by extraction and 180s WSLg AppRun soak with native shard load and autocompile_degraded=0.